### PR TITLE
Migrate from Sanic to FastAPI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,13 +9,13 @@ register-toolchain:
 	rye toolchain register --name=patched-nix-cpython `which python3.13`
 
 dev:
-	bunx --bun concurrently --kill-others "rye run sanic server --dev --port 8070 --host 0.0.0.0" "bunx --bun vite dev --port 8071 --host 0.0.0.0"
+	bunx --bun concurrently --kill-others "rye run fastapi dev --port 8070 --host 0.0.0.0 src/aigis/__init__.py" "bunx --bun vite dev --port 8071 --host 0.0.0.0"
 
 build:
 	bunx --bun vite build
 
 preview:
-	bunx --bun concurrently --kill-others "rye run sanic server --port 8070 --host 0.0.0.0" "bunx --bun vite preview --port 8071 --host 0.0.0.0"
+	bunx --bun concurrently --kill-others "rye run fastapi run --port 8070 --host 0.0.0.0 src/aigis/__init__.py" "bunx --bun vite preview --port 8071 --host 0.0.0.0"
 
 test:
 	bun test #TODO: proper test setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = [
     { name = "bitbloxhub", email = "45184892+bitbloxhub@users.noreply.github.com" }
 ]
 dependencies = [
-    "sanic>=24.6.0",
     "mypy>=1.11.0",
+    "fastapi[standard]>=0.115.4",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"
@@ -18,7 +18,9 @@ build-backend = "hatchling.build"
 
 [tool.rye]
 managed = true
-dev-dependencies = []
+dev-dependencies = [
+    "jedi @ git+https://github.com/davidhalter/jedi@30adf43a8929ade8a9e0abee6921a5043c962215",
+]
 
 [tool.ruff]
 format.indent-style = "tab"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,33 +10,89 @@
 #   universal: false
 
 -e file:.
-aiofiles==24.1.0
-    # via sanic
-html5tagger==1.3.0
-    # via sanic
-    # via tracerite
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.6.2.post1
+    # via httpx
+    # via starlette
+    # via watchfiles
+certifi==2024.8.30
+    # via httpcore
+    # via httpx
+click==8.1.7
+    # via typer
+    # via uvicorn
+dnspython==2.7.0
+    # via email-validator
+email-validator==2.2.0
+    # via fastapi
+fastapi==0.115.4
+    # via aigis
+fastapi-cli==0.0.5
+    # via fastapi
+h11==0.14.0
+    # via httpcore
+    # via uvicorn
+httpcore==1.0.6
+    # via httpx
 httptools==0.6.2
-    # via sanic
-multidict==6.1.0
-    # via sanic
+    # via uvicorn
+httpx==0.27.2
+    # via fastapi
+idna==3.10
+    # via anyio
+    # via email-validator
+    # via httpx
+jedi @ git+https://github.com/davidhalter/jedi@30adf43a8929ade8a9e0abee6921a5043c962215
+jinja2==3.1.4
+    # via fastapi
+markdown-it-py==3.0.0
+    # via rich
+markupsafe==3.0.2
+    # via jinja2
+mdurl==0.1.2
+    # via markdown-it-py
 mypy==1.12.0
     # via aigis
 mypy-extensions==1.0.0
     # via mypy
-sanic==24.6.0
-    # via aigis
-sanic-routing==23.12.0
-    # via sanic
-setuptools==75.2.0
-    # via sanic
-tracerite==1.1.1
-    # via sanic
+parso==0.8.4
+    # via jedi
+pydantic==2.9.2
+    # via fastapi
+pydantic-core==2.23.4
+    # via pydantic
+pygments==2.18.0
+    # via rich
+python-dotenv==1.0.1
+    # via uvicorn
+python-multipart==0.0.17
+    # via fastapi
+pyyaml==6.0.2
+    # via uvicorn
+rich==13.9.4
+    # via typer
+shellingham==1.5.4
+    # via typer
+sniffio==1.3.1
+    # via anyio
+    # via httpx
+starlette==0.41.2
+    # via fastapi
+typer==0.12.5
+    # via fastapi-cli
 typing-extensions==4.12.2
+    # via fastapi
     # via mypy
-    # via sanic
-ujson==5.10.0
-    # via sanic
+    # via pydantic
+    # via pydantic-core
+    # via typer
+uvicorn==0.32.0
+    # via fastapi
+    # via fastapi-cli
 uvloop==0.21.0
-    # via sanic
+    # via uvicorn
+watchfiles==0.24.0
+    # via uvicorn
 websockets==13.1
-    # via sanic
+    # via uvicorn

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,33 +10,86 @@
 #   universal: false
 
 -e file:.
-aiofiles==24.1.0
-    # via sanic
-html5tagger==1.3.0
-    # via sanic
-    # via tracerite
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.6.2.post1
+    # via httpx
+    # via starlette
+    # via watchfiles
+certifi==2024.8.30
+    # via httpcore
+    # via httpx
+click==8.1.7
+    # via typer
+    # via uvicorn
+dnspython==2.7.0
+    # via email-validator
+email-validator==2.2.0
+    # via fastapi
+fastapi==0.115.4
+    # via aigis
+fastapi-cli==0.0.5
+    # via fastapi
+h11==0.14.0
+    # via httpcore
+    # via uvicorn
+httpcore==1.0.6
+    # via httpx
 httptools==0.6.2
-    # via sanic
-multidict==6.1.0
-    # via sanic
+    # via uvicorn
+httpx==0.27.2
+    # via fastapi
+idna==3.10
+    # via anyio
+    # via email-validator
+    # via httpx
+jinja2==3.1.4
+    # via fastapi
+markdown-it-py==3.0.0
+    # via rich
+markupsafe==3.0.2
+    # via jinja2
+mdurl==0.1.2
+    # via markdown-it-py
 mypy==1.12.0
     # via aigis
 mypy-extensions==1.0.0
     # via mypy
-sanic==24.6.0
-    # via aigis
-sanic-routing==23.12.0
-    # via sanic
-setuptools==75.2.0
-    # via sanic
-tracerite==1.1.1
-    # via sanic
+pydantic==2.9.2
+    # via fastapi
+pydantic-core==2.23.4
+    # via pydantic
+pygments==2.18.0
+    # via rich
+python-dotenv==1.0.1
+    # via uvicorn
+python-multipart==0.0.17
+    # via fastapi
+pyyaml==6.0.2
+    # via uvicorn
+rich==13.9.4
+    # via typer
+shellingham==1.5.4
+    # via typer
+sniffio==1.3.1
+    # via anyio
+    # via httpx
+starlette==0.41.2
+    # via fastapi
+typer==0.12.5
+    # via fastapi-cli
 typing-extensions==4.12.2
+    # via fastapi
     # via mypy
-    # via sanic
-ujson==5.10.0
-    # via sanic
+    # via pydantic
+    # via pydantic-core
+    # via typer
+uvicorn==0.32.0
+    # via fastapi
+    # via fastapi-cli
 uvloop==0.21.0
-    # via sanic
+    # via uvicorn
+watchfiles==0.24.0
+    # via uvicorn
 websockets==13.1
-    # via sanic
+    # via uvicorn

--- a/src/aigis/__init__.py
+++ b/src/aigis/__init__.py
@@ -1,9 +1,10 @@
-from sanic import Sanic
-from sanic.response import text
-
-app = Sanic("Aigis")
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 
 
-@app.get("/")
-async def hello_world(request):
-	return text("Hello, world.")
+app = FastAPI()
+
+
+@app.get("/", response_class=PlainTextResponse)
+async def hello_world():
+	return "Hello, world."


### PR DESCRIPTION
Migrate from [Sanic](https://github.com/sanic-org/sanic) to [FastAPI](https://fastapi.tiangolo.com/) because Sanic seems unmaintained.

Also add a pinned [Jedi](https://github.com/davidhalter/jedi) for Python 3.13 support in IDEs.