### PR TITLE
Fix Linter and Formatter.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+
+vendor-node/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,6 @@ export default [
 		},
 	},
 	{
-		ignores: ["build/", ".svelte-kit/", "dist/"],
+		ignores: ["build/", ".svelte-kit/", "dist/", "vendor-node/"],
 	},
 ]


### PR DESCRIPTION
Quick fix to ignore `vendor-node` when running ESLint and Prettier