### PR TITLE
Set insecure cookies in Supabase when in development.

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -19,7 +19,11 @@ export const handle: Handle = async ({ event, resolve }) => {
 					 * will replicate previous/standard behavior (https://kit.svelte.dev/docs/types#public-types-cookies)
 					 */
 					cookiesToSet.forEach(({ name, value, options }) =>
-						event.cookies.set(name, value, { ...options, path: "/" }),
+						event.cookies.set(name, value, {
+							...options,
+							path: "/",
+							secure: import.meta.env.PROD ? true : false,
+						}),
 					)
 				},
 			},

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -22,7 +22,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 						event.cookies.set(name, value, {
 							...options,
 							path: "/",
-							secure: import.meta.env.PROD ? true : false,
+							secure: import.meta.env.PROD,
 						}),
 					)
 				},


### PR DESCRIPTION
Cookies with the [`Secure`](https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Cookies#secure) directive must be sent over HTTPS. Sveltekit sets `HttpOnly` and `Secure` on by default ([source](https://svelte.dev/docs/kit/@sveltejs-kit#Cookies)). Since we do not use HTTPS in development, we need to explicitly tell Sveltekit to only use `Secure` in production.