### PR TITLE
Switch to using Cappuccin CSS Variables for styling

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-@jsr:registry=https://npm.jsr.io

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
 		"@sveltejs/adapter-auto": "^3.3.1",
 		"@sveltejs/kit": "^2.8.1",
 		"@sveltejs/vite-plugin-svelte": "^4.0.1",
-		"@tuhana/unocss-catppuccin": "npm:@jsr/tuhana__unocss-catppuccin",
+		"@types/css-tree": "^2.3.9",
 		"@types/eslint": "^9.6.1",
 		"@unocss/extractor-svelte": "^0.64.1",
 		"concurrently": "^9.1.0",
+		"css-tree": "^3.0.1",
 		"eslint": "9.15.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.46.0",
@@ -28,6 +29,9 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@catppuccin/palette": "^1.7.1",
+		"@fontsource/fira-code": "^5.1.0",
+		"@fontsource/inter": "^5.1.0",
 		"@supabase/ssr": "^0.5.2",
 		"@supabase/supabase-js": "^2.46.1",
 		"svelte-persisted-store": "^0.12.0"

--- a/src/lib/reset.css
+++ b/src/lib/reset.css
@@ -3,8 +3,9 @@
   https://www.joshwcomeau.com/css/custom-css-reset/
 */
 
-@import url(https://rsms.me/inter/inter.css);
-@import url(https://cdn.jsdelivr.net/npm/firacode@6.2.0/distr/fira_code.css);
+@import "@fontsource/inter";
+@import "@fontsource/fira-code";
+@import "@catppuccin/palette/css/catppuccin.css";
 
 *,
 *::before,
@@ -91,17 +92,17 @@ input:-webkit-autofill:active {
 
 /* themes */
 .theme-latte {
-	--at-apply: bg-ctp-latte-base color-ctp-latte-text;
+	--at-apply: bg-[--ctp-latte-base] color-[--ctp-latte-text];
 }
 
 .theme-frappe {
-	--at-apply: bg-ctp-frappe-base color-ctp-frappe-text;
+	--at-apply: bg-[--ctp-frappe-base] color-[--ctp-frappe-text];
 }
 
 .theme-macchiato {
-	--at-apply: bg-ctp-macchiato-base color-ctp-macchiato-text;
+	--at-apply: bg-[--ctp-macchiato-base] color-[--ctp-macchiato-text];
 }
 
 .theme-mocha {
-	--at-apply: bg-ctp-mocha-base color-ctp-mocha-text;
+	--at-apply: bg-[--ctp-mocha-base] color-[--ctp-mocha-text];
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -25,7 +25,7 @@
 	1.00; 9.44, −0.13<br />
 	0:00. 1.13; ~7.12
 </p>
-<code class="font-mono color-ctp-{$preferences.theme}-rosewater">
+<code class="font-mono color-[--ctp-rosewater]">
 	0.45, 0.91. +0.08<br />
 	1.00; 9.44, −0.13<br />
 	0:00. 1.13; ~7.12</code

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -1,11 +1,28 @@
-<form method="POST">
-	<label>
-		Email
-		<input name="email" type="email" />
-	</label>
-	<label>
-		Password
-		<input name="password" type="password" />
-	</label>
-	<button>Log in</button>
-</form>
+<div class="h-screen flex flex-col items-center justify-center">
+	<h1>Log In</h1>
+	<form method="POST">
+		<label class="flex flex-row w-full py-2">
+			<p class="flex-1 text-center px-2">Email</p>
+			<input
+				name="email"
+				type="email"
+				autocomplete="username"
+				class="flex-initial border-2 border-solid border-[--ctp-surface1] rounded-lg color-[--ctp-text] bg-[--ctp-surface0]"
+			/>
+		</label>
+		<label class="flex flex-row w-full py-2">
+			<p class="flex-1 text-center px-2">Password</p>
+			<input
+				name="password"
+				type="password"
+				autocomplete="current-password"
+				class="flex-initial border-2 border-solid border-[--ctp-surface1] rounded-lg color-[--ctp-text] bg-[--ctp-surface0]"
+			/>
+		</label>
+		<div class="flex flex-row justify-center">
+			<button class="w-24 border-0 rounded-lg color-[--ctp-text] bg-[--ctp-surface0]">
+				Log In
+			</button>
+		</div>
+	</form>
+</div>

--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -1,24 +1,47 @@
 <script lang="ts">
-	import { preferences } from "$lib/stores"
 	let password = $state("")
 	let passwordconfirm = $state("")
 </script>
 
-<form method="POST">
-	<label>
-		Email
-		<input name="email" type="email" />
-	</label>
-	<label>
-		Password
-		<input name="password" bind:value={password} type="password" />
-	</label>
-	<label>
-		Confirm Password
-		<input name="password-confirm" bind:value={passwordconfirm} type="password" />
-	</label>
-	{#if password !== passwordconfirm}
-		<p class="color-ctp-{$preferences.theme}-yellow">The passwords do not match!</p>
-	{/if}
-	<button>Sign Up</button>
-</form>
+<div class="h-screen flex flex-col items-center justify-center">
+	<h1>Sign Up</h1>
+	<form method="POST">
+		<label class="flex flex-row w-full py-2">
+			<p class="flex-1 text-center px-2">Email</p>
+			<input
+				name="email"
+				type="email"
+				autocomplete="username"
+				class="flex-initial border-2 border-solid border-[--ctp-surface1] focus:outline-solid focus:outline-1 focus:outline-[--ctp-surface2] focus:border-[--ctp-surface2] rounded-lg color-[--ctp-text] bg-[--ctp-surface0]"
+			/>
+		</label>
+		<label class="flex flex-row w-full py-2">
+			<p class="flex-1 text-center px-2">Password</p>
+			<input
+				name="password"
+				bind:value={password}
+				type="password"
+				autocomplete="new-password"
+				class="flex-initial border-2 border-solid border-[--ctp-surface1] focus:outline-solid focus:outline-1 focus:outline-[--ctp-surface2] focus:border-[--ctp-surface2] rounded-lg color-[--ctp-text] bg-[--ctp-surface0]"
+			/>
+		</label>
+		<label class="flex flex-row w-full py-2">
+			<p class="flex-1 text-center px-2">Confirm Password</p>
+			<input
+				name="password-confirm"
+				bind:value={passwordconfirm}
+				type="password"
+				autocomplete="new-password"
+				class="flex-initial border-2 border-solid border-[--ctp-surface1] focus:outline-solid focus:outline-1 focus:outline-[--ctp-surface2] focus:border-[--ctp-surface2] rounded-lg color-[--ctp-text] bg-[--ctp-surface0]"
+			/>
+		</label>
+		{#if password !== passwordconfirm}
+			<p class="flex flex-row w-full py-2 color-[--ctp-yellow]">The passwords do not match!</p>
+		{/if}
+		<div class="flex flex-row justify-center">
+			<button class="w-24 border-0 rounded-lg color-[--ctp-text] bg-[--ctp-surface0]">
+				Sign Up
+			</button>
+		</div>
+	</form>
+</div>


### PR DESCRIPTION
Use [Catppuccin](https://github.com/catppuccin/catppuccin) [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/--*) instead of [`@tuhana/unocss-catppuccin`](https://github.com/catuhana/unocss-catppuccin/).

Uses [`css-tree`](https://github.com/csstree/csstree) to generate CSS that sets CSS variables like `--ctp-pink` to `hsl(--ctp-(flavor)-pink-hsl)`.

Also styles the forms.

(Split out of #10)