### PR TITLE
Remove webkit prefix from autofill

### DIFF
--- a/src/lib/reset.css
+++ b/src/lib/reset.css
@@ -83,10 +83,10 @@ h6 {
 	fix inputs changing to white on autofill
 	https://stackoverflow.com/questions/2781549/removing-input-background-colour-for-chrome-autocomplete#comment96154809_29350537
 */
-input:-webkit-autofill,
-input:-webkit-autofill:hover,
-input:-webkit-autofill:focus,
-input:-webkit-autofill:active {
+input:autofill,
+input:autofill:hover,
+input:autofill:focus,
+input:autofill:active {
 	transition: all 0s 50000000s;
 }
 


### PR DESCRIPTION
Remove the `-webkit-` vendor prefix from [`input:autofill`](https://developer.mozilla.org/en-US/docs/Web/CSS/:autofill) in [`src/lib/reset.css`](./src/lib/reset.css).

(recreate of #20 because i screwed that up badly (forgot to change base branch))