### PR TITLE
chore(deps): Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
 				"nixpkgs-lib": "nixpkgs-lib"
 			},
 			"locked": {
-				"lastModified": 1727826117,
-				"narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+				"lastModified": 1730504689,
+				"narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
 				"owner": "hercules-ci",
 				"repo": "flake-parts",
-				"rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+				"rev": "506278e768c2a08bec68eb62932193e341f55c90",
 				"type": "github"
 			},
 			"original": {
@@ -20,11 +20,11 @@
 		},
 		"nixpkgs": {
 			"locked": {
-				"lastModified": 1728888510,
-				"narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
+				"lastModified": 1732014248,
+				"narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
 				"owner": "NixOS",
 				"repo": "nixpkgs",
-				"rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+				"rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
 				"type": "github"
 			},
 			"original": {
@@ -36,14 +36,14 @@
 		},
 		"nixpkgs-lib": {
 			"locked": {
-				"lastModified": 1727825735,
-				"narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+				"lastModified": 1730504152,
+				"narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
 				"type": "tarball",
-				"url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+				"url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
 			},
 			"original": {
 				"type": "tarball",
-				"url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+				"url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
 			}
 		},
 		"root": {


### PR DESCRIPTION
Update `flake.lock`.
Please run `rye toolchain remove patched-nix-cpython@3.13.0` and then `just register-toolchain` to use the newer python.