### PR TITLE
fix(backend): remove `asynccontextmanager` annotations

### DIFF
--- a/src/aigis/test_something.py
+++ b/src/aigis/test_something.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 from psycopg import AsyncConnection
@@ -25,5 +27,5 @@ async def test_root(server: AsyncClient):
 
 async def test_postgres():
 	pg: AsyncConnection
-	async with postgres_client(None) as pg:  # pyright: ignore [reportArgumentType] # noqa: F841
+	async with asynccontextmanager(postgres_client)(None) as pg:  # pyright: ignore [reportArgumentType] # noqa: F841
 		pass

--- a/src/aigis/utils.py
+++ b/src/aigis/utils.py
@@ -1,6 +1,5 @@
 import os
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 from typing import Annotated, LiteralString
 
 from fastapi import Depends, Request
@@ -61,7 +60,6 @@ async def openai_client(_request: Request) -> AsyncGenerator[AsyncOpenAI]:
 		pass
 
 
-@asynccontextmanager
 async def postgres_client(_request: Request) -> AsyncGenerator[AsyncConnection]:
 	conn = await AsyncConnection.connect(postgres_url)
 	await register_vector_async(conn)


### PR DESCRIPTION
When annotating dependencies with `asynccontextmanager`, the actual object passed to the function that depends on it will receive the context manager instead of the actual Postgres client.

See https://github.com/fastapi/fastapi/discussions/9054 for more info.